### PR TITLE
datapack map support

### DIFF
--- a/Aetherial Islands/data/minecraft/worldgen/density_function/overworld/map_simple_terrain.json
+++ b/Aetherial Islands/data/minecraft/worldgen/density_function/overworld/map_simple_terrain.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:range_choice",
+    "input": "skylands:continents/oceanic_terrain_limiter",
+    "min_inclusive": -1.05,
+    "max_exclusive": -0.195,
+    "when_in_range": {
+        "type": "minecraft:interpolated",
+        "argument": "skylands:islands/oceanic/final"
+    },
+    "when_out_of_range": "skylands:terrain/pre_caves"
+}

--- a/Aetherial Islands/data/minecraft/worldgen/density_function/overworld/snowcapped_surface.json
+++ b/Aetherial Islands/data/minecraft/worldgen/density_function/overworld/snowcapped_surface.json
@@ -1,0 +1,32 @@
+{
+  "type": "minecraft:cache_once",
+  "argument": {
+    "type": "minecraft:range_choice",
+    "input": "skylands:y",
+    "min_inclusive": -64,
+    "max_exclusive": 48,
+    "when_in_range": "skylands:islands/layer1/surface",
+    "when_out_of_range": {
+      "type": "minecraft:range_choice",
+      "input": "skylands:y",
+      "min_inclusive": 48,
+      "max_exclusive": 96,
+      "when_in_range": "skylands:islands/layer2/surface",
+      "when_out_of_range": {
+        "type": "minecraft:range_choice",
+        "input": "skylands:y",
+        "min_inclusive": 96,
+        "max_exclusive": 144,
+        "when_in_range": "skylands:islands/layer3/surface",
+        "when_out_of_range": {
+          "type": "minecraft:range_choice",
+          "input": "skylands:y",
+          "min_inclusive": 144,
+          "max_exclusive": 192,
+          "when_in_range": "skylands:islands/layer4/surface",
+          "when_out_of_range": "skylands:islands/layer5/surface"
+        }
+      }
+    }
+  }
+}

--- a/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer1/surface.json
+++ b/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer1/surface.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:range_choice",
+  "input": "skylands:continents/noise",
+  "min_inclusive": -1000,
+  "max_exclusive": 0,
+  "when_in_range": 62,
+  "when_out_of_range": {
+    "type": "add",
+    "argument1": -2,
+    "argument2": {
+      "type": "mul",
+      "argument1": 65,
+      "argument2": "skylands:islands/layer1/offset_top"
+    }
+  }
+}

--- a/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer2/surface.json
+++ b/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer2/surface.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:range_choice",
+  "input": "skylands:continents/noise",
+  "min_inclusive": -1000,
+  "max_exclusive": 0,
+  "when_in_range": 62,
+  "when_out_of_range": {
+    "type": "add",
+    "argument1": 46,
+    "argument2": {
+      "type": "mul",
+      "argument1": 65,
+      "argument2": "skylands:islands/layer2/offset_top"
+    }
+  }
+}

--- a/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer3/surface.json
+++ b/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer3/surface.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:range_choice",
+  "input": "skylands:continents/base",
+  "min_inclusive": -1.05,
+  "max_exclusive": -0.195,
+  "when_in_range": 94,
+  "when_out_of_range": {
+    "type": "add",
+    "argument1": 94,
+    "argument2": {
+      "type": "mul",
+      "argument1": 65,
+      "argument2": "skylands:islands/layer3/offset_top"
+    }
+  }
+}

--- a/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer4/surface.json
+++ b/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer4/surface.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:range_choice",
+  "input": "skylands:continents/base",
+  "min_inclusive": -1.05,
+  "max_exclusive": -0.195,
+  "when_in_range": 142,
+  "when_out_of_range": {
+    "type": "add",
+    "argument1": 142,
+    "argument2": {
+      "type": "mul",
+      "argument1": 65,
+      "argument2": "skylands:islands/layer4/offset_top"
+    }
+  }
+}

--- a/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer5/surface.json
+++ b/Aetherial Islands/data/skylands/worldgen/density_function/islands/layer5/surface.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:range_choice",
+  "input": "skylands:continents/base",
+  "min_inclusive": -1.05,
+  "max_exclusive": -0.195,
+  "when_in_range": 190,
+  "when_out_of_range": {
+    "type": "add",
+    "argument1": 190,
+    "argument2": {
+      "type": "mul",
+      "argument1": 65,
+      "argument2": "skylands:islands/layer5/offset_top"
+    }
+  }
+}


### PR DESCRIPTION
adds proper terrain shading support on https://map.jacobsjo.eu

This now doesn't just shade areas that aren't part of the island in dark, but also does proper terrain shading. This is done by providing a 3d `snowcapped_surface` density function that returns the height of the current island layer.
![image](https://github.com/user-attachments/assets/639082a8-bddd-4420-8c81-2f1c7e9aba4a)
